### PR TITLE
Modify SMTPMailer to use GTA smtp settings

### DIFF
--- a/lib/grape_token_auth/mail/smtp_mailer.rb
+++ b/lib/grape_token_auth/mail/smtp_mailer.rb
@@ -8,6 +8,7 @@ module GrapeTokenAuth
       end
 
       def send_mail
+        set_smtp_config
         email.deliver
       end
 
@@ -31,6 +32,12 @@ module GrapeTokenAuth
       end
 
       protected
+
+      def set_smtp_config
+        config = GrapeTokenAuth.configuration.smtp_configuration
+        return if config.empty?
+        email.delivery_method(:smtp, config)
+      end
 
       def prepare_html
         part = ::Mail::Part.new

--- a/spec/lib/grape_token_auth/mail/smtp_mailer_spec.rb
+++ b/spec/lib/grape_token_auth/mail/smtp_mailer_spec.rb
@@ -1,7 +1,52 @@
 module GrapeTokenAuth
   module Mail
     RSpec.describe SMTPMailer do
+      include ::Mail::Matchers
+
       it_behaves_like 'a grape token auth mailer'
+      describe 'message delivery' do
+        let(:email) { email_double }
+        let(:smtp_configuration) do
+          {
+            address:              'localhost',
+            port:                 25,
+            domain:               'localhost.localdomain',
+            user_name:            nil,
+            password:             nil,
+            authentication:       nil,
+            enable_starttls_auto: true
+          }
+        end
+
+        before do
+          @old_config = GrapeTokenAuth.configuration.smtp_configuration
+          GrapeTokenAuth.configure do |config|
+            config.smtp_configuration = smtp_configuration
+            config.from_address = 'from@foo.bar'
+          end
+        end
+
+        after do
+          GrapeTokenAuth.configuration.smtp_configuration = @old_config
+        end
+
+        it "uses the configuration under 'smtp_configuration'" do
+          mailer = described_class.new(email, to: 'test@test.com')
+          mailer.prepare_email!
+          expect_any_instance_of(::Mail::Message)
+            .to receive(:delivery_method).with(:smtp, smtp_configuration)
+          expect_any_instance_of(::Mail::Message).to receive(:deliver)
+          mailer.send_mail
+        end
+      end
+
+      def email_double
+        email = double('email')
+        allow(email).to receive(:html_body).and_return('html body')
+        allow(email).to receive(:subject).and_return('Some subject')
+        allow(email).to receive(:text_body).and_return('text body')
+        email
+      end
     end
   end
 end


### PR DESCRIPTION
Previously, Mail never got the settings from
configuration.smtp_configuration. This commit passes them along per
message.

Fixes #23