### PR TITLE
Validation error message reads wrong for password and password confirmation mismatch

### DIFF
--- a/lib/grape_token_auth/orm_integrations/active_record_token_auth.rb
+++ b/lib/grape_token_auth/orm_integrations/active_record_token_auth.rb
@@ -81,8 +81,8 @@ module GrapeTokenAuth
       def password_confirmation_matches
         return if password.present? && password_confirmation.present? &&
                   password == password_confirmation
-        errors.add(:password_confirmation,
-                   'password confirmation does not match')
+        errors.add(:base,
+                   'password and password confirmation do not match')
       end
 
       def create_new_auth_token(client_id = nil)


### PR DESCRIPTION
When Password and Password Confirmation is not the same, the validation error message reads like this:

_"Validation failed: Password confirmation password confirmation does not match"._

It reads wrong.

So, to fix this, the error is added on the ':base' key instead of the ':password_confirmation' key of the error object. Now it would read:

_"Validation failed: password and password confirmation do not match"_