### PR TITLE
Fix session reading while using on Rails

### DIFF
--- a/lib/grape_token_auth/apis/omniauth_api.rb
+++ b/lib/grape_token_auth/apis/omniauth_api.rb
@@ -6,7 +6,14 @@ module GrapeTokenAuth
     def self.included(base)
       base.helpers do
         def auth_hash
-          @auth_hash ||= request.env['rack.session'].delete('gta.omniauth.auth')
+          @auth_hash ||= begin
+            hash = request.env['rack.session'].delete('gta.omniauth.auth')
+
+            # While using Grape on Rails, #session is an ActionDispatch::Request::Session class,
+            # which does not preserve OmniAuth::AuthHash class @ 'gta.omniauth.auth' key,
+            # converting it to Hash. Restoring
+            hash.kind_of?(::OmniAuth::AuthHash) ? hash : ::OmniAuth::AuthHash.new(hash)
+          end
         end
 
         def omniauth_params


### PR DESCRIPTION
This is also cause empty values for attrs hash while reading it in ``omniauth_resource.rb``, since info_hash has strings as keys:

```ruby
def assign_provider_attrs
  info_hash = auth_hash['info']
  attrs = %i(nickname name image email).each_with_object({}) do |k, hsh|
    hsh[k] = info_hash.fetch(k, '')
  end
  resource.assign_attributes(attrs)
end
```