### PR TITLE
Modify session api to used `authed_with_token` data key

### DIFF
--- a/lib/grape_token_auth/apis/session_api.rb
+++ b/lib/grape_token_auth/apis/session_api.rb
@@ -26,10 +26,7 @@ module GrapeTokenAuth
         data = AuthorizerData.load_from_env_or_create(env)
         env['rack.session'] ||= {}
         data.store_resource(resource, base.resource_scope)
-        auth_header = AuthenticationHeader.new(data, start_time)
-        auth_header.headers.each do |key, value|
-          header key.to_s, value.to_s
-        end
+        data.authed_with_token = false
         status 200
         present data: resource
       end


### PR DESCRIPTION
Change the session API so that it doesn't set the authentication headers
within the sign in end point. Instead, use the flag on Authorizer Data,
to indicate that the user was not authenticated with a token, which
causes the headers to be created within the middleware.

Fix one for #39

There is a double request for uniqueness because validation is checked twice. Unclear what else should change. 