### PR TITLE
Fix sign-out on Rails

### DIFF
--- a/lib/grape_token_auth/apis/session_api.rb
+++ b/lib/grape_token_auth/apis/session_api.rb
@@ -39,7 +39,10 @@ module GrapeTokenAuth
         resource = find_resource(data, base.resource_scope)
 
         if resource
-          resource.tokens.delete(env[Configuration::CLIENT_KEY])
+          # Rails prepends 'CLIENT' header with 'HTTP_' prefix, so to make sure we address to
+          # proper header, better use normalized version stored at <tt>data</tt>
+          # See more: http://stackoverflow.com/a/26936364/1592582
+          resource.tokens.delete(data.client_id)
           data.skip_auth_headers = true
           resource.save
           status 200

--- a/spec/lib/grape_token_auth/apis/session_api_spec.rb
+++ b/spec/lib/grape_token_auth/apis/session_api_spec.rb
@@ -95,7 +95,7 @@ module GrapeTokenAuth
 
         it 'destroys the token' do
           existing_user.reload
-          expect(existing_user.tokens[auth_headers['client']]).to be_nil
+          expect(existing_user.tokens).to be_empty
         end
 
         it 'does not return auth headers' do


### PR DESCRIPTION
Rails prepends 'CLIENT' header with 'HTTP_' prefix. But we use 'CLIENT' env key
to delete token from User.tokens.

Replaced with normalized header name.

More info:

http://stackoverflow.com/q/26936318/1592582
https://github.com/rails/rails/blob/4-2-stable/actionpack/lib/action_dispatch/http/headers.rb#L87-L96