### PR TITLE
Allow using class name for mappings

### DIFF
--- a/lib/grape_token_auth/configuration.rb
+++ b/lib/grape_token_auth/configuration.rb
@@ -75,7 +75,8 @@ module GrapeTokenAuth
 
     def scope_to_class(scope = nil)
       fail MappingsUndefinedError if mappings.empty?
-      mappings[scope]
+
+      mappings[scope].is_a?(String) ? mappings[scope].constantize : mappings[scope]
     end
   end
 end

--- a/lib/grape_token_auth/token_authorizer.rb
+++ b/lib/grape_token_auth/token_authorizer.rb
@@ -33,7 +33,7 @@ module GrapeTokenAuth
     attr_reader :resource_class, :user, :resource
 
     def initialize_resource_class(scope)
-      @resource_class =  GrapeTokenAuth.configuration.scope_to_class(scope)
+      @resource_class = GrapeTokenAuth.configuration.scope_to_class(scope)
     end
 
     def load_user_from_uid


### PR DESCRIPTION
I'm using it with an Rails app and I have a trouble with loading User model in the initializer. Maybe we can use just class name?

I offer to switch to sqlite for test because not all use postgres. And how can I run tests if there is no database structure? Maybe we can add an sqlite database with all tables empty? 