### PR TITLE
Add FrozenStringLiteral comments

### DIFF
--- a/lib/grape_token_auth.rb
+++ b/lib/grape_token_auth.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'bcrypt'
 require 'forwardable'
 require 'grape'

--- a/lib/grape_token_auth/api_helpers.rb
+++ b/lib/grape_token_auth/api_helpers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   module ApiHelpers
     def self.included(base)

--- a/lib/grape_token_auth/apis/confirmation_api.rb
+++ b/lib/grape_token_auth/apis/confirmation_api.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   # Module that contains the majority of the email confirming functionality.
   # This module can be included in a Grape::API class that defines a

--- a/lib/grape_token_auth/apis/omniauth_api.rb
+++ b/lib/grape_token_auth/apis/omniauth_api.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   # Module that contains the majority of the OmniAuth functionality. This module
   # can be included in a Grape::API class that defines a resource_scope and

--- a/lib/grape_token_auth/apis/password_api.rb
+++ b/lib/grape_token_auth/apis/password_api.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   # Module that contains the majority of the password reseting functionality.
   # This module can be included in a Grape::API class that defines a

--- a/lib/grape_token_auth/apis/registration/endpoint_definer.rb
+++ b/lib/grape_token_auth/apis/registration/endpoint_definer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   module Registration
     class EndpointDefiner

--- a/lib/grape_token_auth/apis/registration/helpers.rb
+++ b/lib/grape_token_auth/apis/registration/helpers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   module Registration
     module Helpers

--- a/lib/grape_token_auth/apis/registration_api.rb
+++ b/lib/grape_token_auth/apis/registration_api.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   module RegistrationAPICore
     def self.included(base)

--- a/lib/grape_token_auth/apis/session_api.rb
+++ b/lib/grape_token_auth/apis/session_api.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   module SessionsAPICore
     def self.included(base)

--- a/lib/grape_token_auth/apis/token_validation_api.rb
+++ b/lib/grape_token_auth/apis/token_validation_api.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   # Contains the major functionality of TokenValidation
   module TokenValidationAPICore

--- a/lib/grape_token_auth/authentication_header.rb
+++ b/lib/grape_token_auth/authentication_header.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   class AuthenticationHeader
     extend Forwardable

--- a/lib/grape_token_auth/authorizer_data.rb
+++ b/lib/grape_token_auth/authorizer_data.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   class AuthorizerData
     RACK_ENV_KEY = 'gta.auth_data'

--- a/lib/grape_token_auth/configuration.rb
+++ b/lib/grape_token_auth/configuration.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   class Configuration
     ACCESS_TOKEN_KEY = 'access-token'

--- a/lib/grape_token_auth/exceptions.rb
+++ b/lib/grape_token_auth/exceptions.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   # Error when an undefined scope was attempted to be used
   class ScopeUndefinedError < StandardError

--- a/lib/grape_token_auth/key_generator.rb
+++ b/lib/grape_token_auth/key_generator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'thread_safe'
 require 'openssl'
 require 'securerandom'

--- a/lib/grape_token_auth/lookup_token.rb
+++ b/lib/grape_token_auth/lookup_token.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   # Look up tokens are a type of token that allows searching by that token. This
   # is useful in use cases such as confirmation tokens. These type of tokens are

--- a/lib/grape_token_auth/mail/mail.rb
+++ b/lib/grape_token_auth/mail/mail.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   module Mail
     DEFAULT_MESSAGES = {

--- a/lib/grape_token_auth/mail/message_base.rb
+++ b/lib/grape_token_auth/mail/message_base.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   module Mail
     class MessageBase

--- a/lib/grape_token_auth/mail/messages/confirmation/confirmation_email.rb
+++ b/lib/grape_token_auth/mail/messages/confirmation/confirmation_email.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   module Mail
     class ConfirmationEmail < MessageBase

--- a/lib/grape_token_auth/mail/messages/password_reset/password_reset_email.rb
+++ b/lib/grape_token_auth/mail/messages/password_reset/password_reset_email.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   module Mail
     class PasswordResetEmail < MessageBase

--- a/lib/grape_token_auth/mail/smtp_mailer.rb
+++ b/lib/grape_token_auth/mail/smtp_mailer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   module Mail
     class SMTPMailer

--- a/lib/grape_token_auth/middleware.rb
+++ b/lib/grape_token_auth/middleware.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   class Middleware
     def initialize(app, _options)

--- a/lib/grape_token_auth/mount_helpers.rb
+++ b/lib/grape_token_auth/mount_helpers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   module MountHelpers
     def self.included(base)

--- a/lib/grape_token_auth/omniauth/omniauth_failure_html.rb
+++ b/lib/grape_token_auth/omniauth/omniauth_failure_html.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   class OmniAuthFailureHTML < OmniAuthHTMLBase
     FAILURE_MESSAGE = 'authFailure'

--- a/lib/grape_token_auth/omniauth/omniauth_html_base.rb
+++ b/lib/grape_token_auth/omniauth/omniauth_html_base.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'erb'
 require 'json'
 

--- a/lib/grape_token_auth/omniauth/omniauth_resource.rb
+++ b/lib/grape_token_auth/omniauth/omniauth_resource.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   class OmniAuthResource
     extend Forwardable

--- a/lib/grape_token_auth/omniauth/omniauth_success_html.rb
+++ b/lib/grape_token_auth/omniauth/omniauth_success_html.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   class OmniAuthSuccessHTML < OmniAuthHTMLBase
     extend Forwardable

--- a/lib/grape_token_auth/orm_integrations/active_record_token_auth.rb
+++ b/lib/grape_token_auth/orm_integrations/active_record_token_auth.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   module ActiveRecord
     module TokenAuth

--- a/lib/grape_token_auth/resource/resource_creator.rb
+++ b/lib/grape_token_auth/resource/resource_creator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   class ResourceCreator < ResourceCrudBase
     def create!

--- a/lib/grape_token_auth/resource/resource_crud_base.rb
+++ b/lib/grape_token_auth/resource/resource_crud_base.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   class ResourceCrudBase
     attr_reader :resource, :errors, :scope

--- a/lib/grape_token_auth/resource/resource_finder.rb
+++ b/lib/grape_token_auth/resource/resource_finder.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   class ResourceFinder
     def initialize(scope, params)

--- a/lib/grape_token_auth/resource/resource_updater.rb
+++ b/lib/grape_token_auth/resource/resource_updater.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   class ResourceUpdater < ResourceCrudBase
     def initialize(resource, params, configuration, scope = :user)

--- a/lib/grape_token_auth/token.rb
+++ b/lib/grape_token_auth/token.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   class Token
     attr_reader :token, :client_id, :expiry

--- a/lib/grape_token_auth/token_authentication.rb
+++ b/lib/grape_token_auth/token_authentication.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   module TokenAuthentication
     def self.included(base)

--- a/lib/grape_token_auth/token_authorizer.rb
+++ b/lib/grape_token_auth/token_authorizer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   class TokenAuthorizer
     attr_reader :data

--- a/lib/grape_token_auth/unauthorized_middleware.rb
+++ b/lib/grape_token_auth/unauthorized_middleware.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   class UnauthorizedMiddleware
     def self.call(env)

--- a/lib/grape_token_auth/utility.rb
+++ b/lib/grape_token_auth/utility.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   class Utility
     def self.find_with_indifference(hash, key)

--- a/lib/grape_token_auth/version.rb
+++ b/lib/grape_token_auth/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   VERSION = '0.1.0'
 end

--- a/spec/database.rb
+++ b/spec/database.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'yaml'
 require 'active_record'
 

--- a/spec/factories/man.rb
+++ b/spec/factories/man.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 FactoryGirl.define do
   factory :man do
     sequence(:email) { |n| "someperson#{n}@example.com" }

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 FactoryGirl.define do
   factory :user do
     sequence(:email) { |n| "someperson#{n}@example.com" }

--- a/spec/feature/authentication_spec.rb
+++ b/spec/feature/authentication_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 RSpec.describe 'Getting a protected route'  do
   include Warden::Test::Helpers

--- a/spec/feature/grape_helpers_spec.rb
+++ b/spec/feature/grape_helpers_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe 'Getting a route' do

--- a/spec/grape_token_auth/utility_spec.rb
+++ b/spec/grape_token_auth/utility_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   RSpec.describe Utility do
     describe '.humanize' do

--- a/spec/grape_token_auth_spec.rb
+++ b/spec/grape_token_auth_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe GrapeTokenAuth do

--- a/spec/lib/grape_token_auth/api_helpers_spec.rb
+++ b/spec/lib/grape_token_auth/api_helpers_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   describe ApiHelpers do
     context 'with mappings defined' do

--- a/spec/lib/grape_token_auth/apis/confirmation_api_spec.rb
+++ b/spec/lib/grape_token_auth/apis/confirmation_api_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   RSpec.describe ConfirmationAPI, confirmable: true do
     let(:mail) do

--- a/spec/lib/grape_token_auth/apis/omniauth_api_spec.rb
+++ b/spec/lib/grape_token_auth/apis/omniauth_api_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   describe OmniAuthAPI do
     let(:redirect_url) { 'http://example.org/' }

--- a/spec/lib/grape_token_auth/apis/password_api_spec.rb
+++ b/spec/lib/grape_token_auth/apis/password_api_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   RSpec.describe PasswordAPI do
     let(:mail) do

--- a/spec/lib/grape_token_auth/apis/registration_api_spec.rb
+++ b/spec/lib/grape_token_auth/apis/registration_api_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   describe RegistrationAPI do
     let(:data) { JSON.parse(response.body) }

--- a/spec/lib/grape_token_auth/apis/session_api_spec.rb
+++ b/spec/lib/grape_token_auth/apis/session_api_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   describe SessionsAPI do
     let(:data)           { JSON.parse(response.body) }

--- a/spec/lib/grape_token_auth/apis/token_validation_api_spec.rb
+++ b/spec/lib/grape_token_auth/apis/token_validation_api_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   describe TokenValidationAPI do
     let(:user)         { FactoryGirl.create(:user) }

--- a/spec/lib/grape_token_auth/authentication_header_spec.rb
+++ b/spec/lib/grape_token_auth/authentication_header_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 module GrapeTokenAuth

--- a/spec/lib/grape_token_auth/authorizer_data_spec.rb
+++ b/spec/lib/grape_token_auth/authorizer_data_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 module GrapeTokenAuth

--- a/spec/lib/grape_token_auth/configuration_spec.rb
+++ b/spec/lib/grape_token_auth/configuration_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 module GrapeTokenAuth

--- a/spec/lib/grape_token_auth/lookup_token_spec.rb
+++ b/spec/lib/grape_token_auth/lookup_token_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   RSpec.describe LookupToken do
     describe '.friendly_token' do

--- a/spec/lib/grape_token_auth/mail/mail_spec.rb
+++ b/spec/lib/grape_token_auth/mail/mail_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   RSpec.describe Mail do
     describe '.send' do

--- a/spec/lib/grape_token_auth/mail/messages/confirmation/confirmation_email_spec.rb
+++ b/spec/lib/grape_token_auth/mail/messages/confirmation/confirmation_email_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth::Mail
   RSpec.describe ConfirmationEmail do
     before do

--- a/spec/lib/grape_token_auth/mail/messages/password_reset/password_reset_email_spec.rb
+++ b/spec/lib/grape_token_auth/mail/messages/password_reset/password_reset_email_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth::Mail
   RSpec.describe PasswordResetEmail do
     before do

--- a/spec/lib/grape_token_auth/mail/smtp_mailer_spec.rb
+++ b/spec/lib/grape_token_auth/mail/smtp_mailer_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   module Mail
     RSpec.describe SMTPMailer do

--- a/spec/lib/grape_token_auth/mount_helpers_spec.rb
+++ b/spec/lib/grape_token_auth/mount_helpers_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   RSpec.describe MountHelpers do
     before do

--- a/spec/lib/grape_token_auth/omniauth/omniauth_failure_html_spec.rb
+++ b/spec/lib/grape_token_auth/omniauth/omniauth_failure_html_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   describe OmniAuthFailureHTML do
     subject(:failure_html) { described_class.new(message) }

--- a/spec/lib/grape_token_auth/omniauth/omniauth_html_base_spec.rb
+++ b/spec/lib/grape_token_auth/omniauth/omniauth_html_base_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   RSpec.describe OmniAuthHTMLBase do
     let(:invalid_error) { 'Invalid OmniAuthHTMLBase class' }

--- a/spec/lib/grape_token_auth/omniauth/omniauth_resource_spec.rb
+++ b/spec/lib/grape_token_auth/omniauth/omniauth_resource_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   RSpec.describe OmniAuthResource do
     let(:resource) { instance_double('User') }

--- a/spec/lib/grape_token_auth/omniauth/omniauth_success_html_spec.rb
+++ b/spec/lib/grape_token_auth/omniauth/omniauth_success_html_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   RSpec.describe OmniAuthSuccessHTML do
     let(:oauth_resource) { instance_double('GrapeTokenAuth::OmniAuthResource') }

--- a/spec/lib/grape_token_auth/orm_integrations/active_record_token_auth_spec.rb
+++ b/spec/lib/grape_token_auth/orm_integrations/active_record_token_auth_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 module GrapeTokenAuth

--- a/spec/lib/grape_token_auth/resource/resource_creator_spec.rb
+++ b/spec/lib/grape_token_auth/resource/resource_creator_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   describe ResourceCreator do
     let(:configuration) { instance_double(Configuration) }

--- a/spec/lib/grape_token_auth/resource/resource_finder_spec.rb
+++ b/spec/lib/grape_token_auth/resource/resource_finder_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   describe ResourceFinder do
     describe '.find' do

--- a/spec/lib/grape_token_auth/resource/resource_updater_spec.rb
+++ b/spec/lib/grape_token_auth/resource/resource_updater_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   describe ResourceUpdater do
     let(:configuration) { instance_double(Configuration) }

--- a/spec/lib/grape_token_auth/token_authentication_spec.rb
+++ b/spec/lib/grape_token_auth/token_authentication_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 module GrapeTokenAuth

--- a/spec/lib/grape_token_auth/token_authorizer_spec.rb
+++ b/spec/lib/grape_token_auth/token_authorizer_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 module GrapeTokenAuth

--- a/spec/lib/grape_token_auth/token_spec.rb
+++ b/spec/lib/grape_token_auth/token_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   describe Token do
     before { Timecop.freeze }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'codeclimate-test-reporter'
 
 CodeClimate::TestReporter.start do

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GrapeTokenAuth
   # Spec Helpers for GrapeTokenAuth testing. Primarily does a little syntatic
   # sugary stuff aroung rack-test to be similar to airborne

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 RSpec.shared_examples 'a grape token auth email' do
   it { is_expected.to respond_to :text_body }
   it { is_expected.to respond_to :html_body }

--- a/spec/test_apps/models/man.rb
+++ b/spec/test_apps/models/man.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Man < ActiveRecord::Base
   include GrapeTokenAuth::ActiveRecord::TokenAuth
 end

--- a/spec/test_apps/models/post.rb
+++ b/spec/test_apps/models/post.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Post
   def self.all
     [{ body: 'these would be some posts' }, { body: 'good times' }]

--- a/spec/test_apps/models/user.rb
+++ b/spec/test_apps/models/user.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class User < ActiveRecord::Base
   include GrapeTokenAuth::ActiveRecord::TokenAuth
   validates :operating_thetan, numericality: { greater_than: -1 }

--- a/spec/test_apps/test_app.rb
+++ b/spec/test_apps/test_app.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 root_dir = File.expand_path('../models', __FILE__)
 Dir.glob(root_dir + '/*.rb').each { |path| require path }
 


### PR DESCRIPTION
Ruby 2.3 introduces the ability to make strings immutable. By adding
this comment, the feature is enabled for any code where this comment
exists. These comments can be removed in ruby 3.0.